### PR TITLE
AGENTOPS-2181 add xvfb to installed packages list

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,6 +113,7 @@ class te_agent(
   Optional[Boolean] $agent_service_enable                    = undef,
   Boolean $agent_utils                                       = false,
   Boolean $browserbot                                        = false,
+  Boolean $xvfb                                              = false,
   Integer[0,1] $crash_reports                                = 1,
   Boolean $international_langs                               = false,
   Integer[0] $log_file_size                                  = 10,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,6 +18,11 @@ class te_agent::install {
     false => 'purged',
   }
 
+  $xvfb_package_ensure = $te_agent::xvfb ? {
+    true  => 'installed',
+    false => 'purged',
+  }
+
   $agent_utils_package_ensure = $te_agent::agent_utils ? {
     true  => 'installed',
     false => 'purged',
@@ -34,6 +39,11 @@ class te_agent::install {
 
   package { 'te-browserbot':
     ensure  => $browserbot_package_ensure,
+    require => Package['te-agent'],
+  }
+
+  package { 'te-xvfb':
+    ensure  => $xvfb_package_ensure,
     require => Package['te-agent'],
   }
 


### PR DESCRIPTION
It will no longer be a debian package dependency of browserbot as described in
BBOT-1692, but all cloud agents will still need it.