### PR TITLE
AGENTOPS-25184: Develop Ubuntu 22.04 Jammy upgrade automation - Puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This Puppet module installs and configures the ThousandEyes Enterprise Agent.
 
 ## Platform
 
-- Ubuntu 14.04(trusty), 16.04 (xenial) and 18.04 (Bionic)
-- CentOS/RedHat >=6.3
+- Ubuntu 16.04 (xenial), 18.04 (bionic), 20.04 (focal) and 22.04 (jammy)
+- CentOS/RedHat 7, 8 and 9
 
-**Note:** This module needs Puppet 4 or Puppet 5. If you want the version for Puppet 3.7, check the `puppet3.7` tag.
+**Note:** This module needs Puppet 4.x or 5.x. If you want the version for Puppet 3.7, check the `puppet3.7` tag.
 
 ## Usage
 
@@ -61,7 +61,7 @@ ThousandEyes Enterprise Agent.
 
 Execute the following command to use the provided example manifest:
 
-```puppet apply --modulepath path_to_module examples/init.pp```
+`puppet apply --modulepath path_to_module examples/init.pp`
 
 ## License
 

--- a/manifests/dependency.pp
+++ b/manifests/dependency.pp
@@ -9,24 +9,40 @@
 class te_agent::dependency{
 
   $os_family   = $facts['os']['family']
-  $os_release  = $facts['os']['release']['full']
+  $os_distro   = $facts['os']['distro']['id']
+  $os_codename = $facts['os']['distro']['codename']
+  $os_release  = $facts['os']['release']['major']
 
   case $os_family {
 
-    'RedHat': {
-      if (versioncmp($os_release,'6.3') <= 0 ) {
-        fail("Please upgrade your operating system ${os_family} ${os_release} to version 6.3 or newer.")
+    'Debian': {
+      case $os_distro {
+        'Ubuntu': {
+          if !($os_codename in ['xenial', 'bionic', 'focal', 'jammy']) {
+            fail('Only Ubuntu 16.04 (xenial), 18.04 (bionic), 20.04 (focal) and 22.04 (jammy) are supported. Please contact support.')
+          }
+        }
+        default: {
+          fail("Operating system ${os_distro} ${os_release} ${os_codename} is not supported.")
+        }
       }
     }
 
-    'Debian': {
-      if !($os_release in ['16.04','18.04', '20.04']) {
-        fail('Only Ubuntu 16.04 (xenial), 18.04 (bionic), and 20.04 (focal) are supported. Please contact support.')
+    'RedHat': {
+      case $os_distro {
+        'CentOS', 'RedHat': {
+          if !($os_release in ['7', '8', '9']) {
+            fail('Only CentOS/RHEL 7, 8 and 9 are supported. Please contact support.')
+          }
+        }
+        default: {
+          fail("Operating system ${os_distro} ${os_release} ${os_codename} is not supported.")
+        }
       }
     }
 
     default: {
-      fail("Operating system ${os_family} ${os_release} is not supported.")
+      fail("Operating system ${os_family} family is not supported.")
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -9,22 +9,35 @@
   "dependencies": [],
   "operatingsystem_support": [
     {
-    "operatingsystem":"RedHat",
-    "operatingsystemrelease": [">= 6.3"]
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "16.04",
+        "18.04",
+        "20.04",
+        "22.04"
+      ]
     },
     {
-    "operatingsystem": "Ubuntu",
-    "operatingsystemrelease": [
-      "14.04",
-      "16.04",
-      "18.04"
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7",
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7",
+        "8",
+        "9"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 "
+      "version_requirement": ">= 4.0.0"
     }
   ]
 }


### PR DESCRIPTION
[AGENTOPS-25184](https://thousandeyes.atlassian.net/browse/AGENTOPS-25184)

Refactoring to support:
- Ubuntu 16.04 Xenial, 18.04 Bionic, 20.04 Focal and 22.04 Jammy as per https://apt.thousandeyes.com/
- CentOS/RHEL 7, 8 and 9 as per https://yum.thousandeyes.com/

[AGENTOPS-25184]: https://thousandeyes.atlassian.net/browse/AGENTOPS-25184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ